### PR TITLE
Trying a few things here

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ log/*
 node_modules/*
 __pycache__/*
 piazza/downloads*
+lemur-stopwords.txt

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ gulp server
 7. Install python dependencies
 
 ```bash
+wget -nc https://raw.githubusercontent.com/meta-toolkit/meta/master/data/lemur-stopwords.txt
 pip install -r requirements.txt
 ```
 

--- a/app.py
+++ b/app.py
@@ -436,10 +436,31 @@ def socket_connection(course_name=None, lno=None, slide_name=None, curr_slide=No
 
 @app.route("/search", methods=["POST"])
 def results(course_name=None, lno=None, slide_name=None, curr_slide=None):
-    data = json.loads(request.data.decode("utf-8"))
-    # print(1,1,data)
-    querytext = data["searchString"]
+    querytext = request.json.get("searchString", None)
+    if not querytext:
+        return jsonify({})
     explanation, file_names = model.get_explanation(querytext)
+    if explanation == "":
+        num_results = 0
+    else:
+        num_results = 1
+    response = jsonify(
+        {
+            "num_results": num_results,
+            "explanation": explanation,
+            "file_names": file_names,
+        }
+    )
+    # print(response)
+    return response
+
+
+@app.route("/rank_piazza", methods=["POST"])
+def piazza_results(course_name=None, lno=None, slide_name=None, curr_slide=None):
+    querytext = request.json.get("searchString", None)
+    if not querytext:
+        return jsonify({})
+    explanation, file_names = model.get_explanation(querytext, top_k=20)
     if explanation == "":
         num_results = 0
     else:
@@ -573,4 +594,3 @@ def log_action():
 
 if __name__ == "__main__":
     socketio.run(app, host="localhost", port=8096)
-

--- a/para_idx_data/config.toml
+++ b/para_idx_data/config.toml
@@ -1,5 +1,5 @@
 index = "paras_nohead"
-prefix = "/Users/bhavya/Documents/explanation/UI"
+prefix = "."
 corpus = "file.toml"
 dataset = "para_idx_data"
 query-judgements = "slide-qrels.txt"

--- a/pdf.js/build/generic/web/viewer.html
+++ b/pdf.js/build/generic/web/viewer.html
@@ -21,411 +21,479 @@ Adobe CMap resources are covered by their own copyright but the same license:
 See https://github.com/adobe-type-tools/cmap-resources
 -->
 <html dir="ltr" mozdisallowselectionprint>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
-    <meta name="google" content="notranslate">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <title>PDF.js viewer</title>
 
-    <link rel="stylesheet" href="viewer.css">
-<script src="http://timan102.cs.illinois.edu/explanation//static/jquery-3.4.1.min.js"></script>
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1">
+  <meta name="google" content="notranslate">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge">
+  <title>PDF.js viewer</title>
 
-<!-- This snippet is used in production (included from viewer.html) -->
-<link rel="resource" type="application/l10n" href="locale/locale.properties">
-<script src="../build/pdf.js"></script>
+  <link rel="stylesheet" href="viewer.css">
+  <script src="http://timan102.cs.illinois.edu/explanation//static/jquery-3.4.1.min.js"></script>
+
+  <!-- This snippet is used in production (included from viewer.html) -->
+  <link rel="resource" type="application/l10n" href="locale/locale.properties">
+  <script src="../build/pdf.js"></script>
 
 
 
-    <script src="viewer.js"></script>
+  <script src="viewer.js"></script>
 
-  </head>
+</head>
 
-  <body tabindex="1" class="loadingInProgress">
-    <div id="outerContainer">
+<body tabindex="1" class="loadingInProgress">
+  <div id="outerContainer">
 
-      <div id="sidebarContainer">
-        <div id="toolbarSidebar">
-          <div class="splitToolbarButton toggled">
-            <button id="viewThumbnail" class="toolbarButton toggled" title="Show Thumbnails" tabindex="2" data-l10n-id="thumbs">
-               <span data-l10n-id="thumbs_label">Thumbnails</span>
+    <div id="sidebarContainer">
+      <div id="toolbarSidebar">
+        <div class="splitToolbarButton toggled">
+          <button id="viewThumbnail" class="toolbarButton toggled" title="Show Thumbnails" tabindex="2"
+            data-l10n-id="thumbs">
+            <span data-l10n-id="thumbs_label">Thumbnails</span>
+          </button>
+          <button id="viewOutline" class="toolbarButton"
+            title="Show Document Outline (double-click to expand/collapse all items)" tabindex="3"
+            data-l10n-id="document_outline">
+            <span data-l10n-id="document_outline_label">Document Outline</span>
+          </button>
+          <button id="viewAttachments" class="toolbarButton" title="Show Attachments" tabindex="4"
+            data-l10n-id="attachments">
+            <span data-l10n-id="attachments_label">Attachments</span>
+          </button>
+        </div>
+      </div>
+      <div id="sidebarContent">
+        <div id="thumbnailView">
+        </div>
+        <div id="outlineView" class="hidden">
+        </div>
+        <div id="attachmentsView" class="hidden">
+        </div>
+      </div>
+      <div id="sidebarResizer" class="hidden"></div>
+    </div> <!-- sidebarContainer -->
+
+    <div id="mainContainer">
+      <div class="findbar hidden doorHanger" id="findbar">
+        <div id="findbarInputContainer">
+          <input id="findInput" class="toolbarField" title="Find" placeholder="Find in document…" tabindex="91"
+            data-l10n-id="find_input">
+          <div class="splitToolbarButton">
+            <button id="findPrevious" class="toolbarButton findPrevious"
+              title="Find the previous occurrence of the phrase" tabindex="92" data-l10n-id="find_previous">
+              <span data-l10n-id="find_previous_label">Previous</span>
             </button>
-            <button id="viewOutline" class="toolbarButton" title="Show Document Outline (double-click to expand/collapse all items)" tabindex="3" data-l10n-id="document_outline">
-               <span data-l10n-id="document_outline_label">Document Outline</span>
-            </button>
-            <button id="viewAttachments" class="toolbarButton" title="Show Attachments" tabindex="4" data-l10n-id="attachments">
-               <span data-l10n-id="attachments_label">Attachments</span>
+            <div class="splitToolbarButtonSeparator"></div>
+            <button id="findNext" class="toolbarButton findNext" title="Find the next occurrence of the phrase"
+              tabindex="93" data-l10n-id="find_next">
+              <span data-l10n-id="find_next_label">Next</span>
             </button>
           </div>
         </div>
-        <div id="sidebarContent">
-          <div id="thumbnailView">
-          </div>
-          <div id="outlineView" class="hidden">
-          </div>
-          <div id="attachmentsView" class="hidden">
-          </div>
-        </div>
-        <div id="sidebarResizer" class="hidden"></div>
-      </div>  <!-- sidebarContainer -->
 
-      <div id="mainContainer">
-        <div class="findbar hidden doorHanger" id="findbar">
-          <div id="findbarInputContainer">
-            <input id="findInput" class="toolbarField" title="Find" placeholder="Find in document…" tabindex="91" data-l10n-id="find_input">
-            <div class="splitToolbarButton">
-              <button id="findPrevious" class="toolbarButton findPrevious" title="Find the previous occurrence of the phrase" tabindex="92" data-l10n-id="find_previous">
-                <span data-l10n-id="find_previous_label">Previous</span>
+        <div id="findbarOptionsOneContainer">
+          <input type="checkbox" id="findHighlightAll" class="toolbarField" tabindex="94">
+          <label for="findHighlightAll" class="toolbarLabel" data-l10n-id="find_highlight">Highlight all</label>
+          <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
+          <label for="findMatchCase" class="toolbarLabel" data-l10n-id="find_match_case_label">Match case</label>
+        </div>
+        <div id="findbarOptionsTwoContainer">
+          <input type="checkbox" id="findEntireWord" class="toolbarField" tabindex="96">
+          <label for="findEntireWord" class="toolbarLabel" data-l10n-id="find_entire_word_label">Whole words</label>
+          <span id="findResultsCount" class="toolbarLabel hidden"></span>
+        </div>
+
+        <div id="findbarMessageContainer">
+          <span id="findMsg" class="toolbarLabel"></span>
+        </div>
+      </div> <!-- findbar -->
+
+      <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
+        <div id="secondaryToolbarButtonContainer">
+          <button id="secondaryPresentationMode" class="secondaryToolbarButton presentationMode visibleLargeView"
+            title="Switch to Presentation Mode" tabindex="51" data-l10n-id="presentation_mode">
+            <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
+          </button>
+
+          <button id="secondaryOpenFile" class="secondaryToolbarButton openFile visibleLargeView" title="Open File"
+            tabindex="52" data-l10n-id="open_file">
+            <span data-l10n-id="open_file_label">Open</span>
+          </button>
+
+          <button id="secondaryPrint" class="secondaryToolbarButton print visibleMediumView" title="Print" tabindex="53"
+            data-l10n-id="print">
+            <span data-l10n-id="print_label">Print</span>
+          </button>
+
+          <button id="secondaryDownload" class="secondaryToolbarButton download visibleMediumView" title="Download"
+            tabindex="54" data-l10n-id="download">
+            <span data-l10n-id="download_label">Download</span>
+          </button>
+
+          <a href="#" id="secondaryViewBookmark" class="secondaryToolbarButton bookmark visibleSmallView"
+            title="Current view (copy or open in new window)" tabindex="55" data-l10n-id="bookmark">
+            <span data-l10n-id="bookmark_label">Current View</span>
+          </a>
+
+          <div class="horizontalToolbarSeparator visibleLargeView"></div>
+
+          <button id="firstPage" class="secondaryToolbarButton firstPage" title="Go to First Page" tabindex="56"
+            data-l10n-id="first_page">
+            <span data-l10n-id="first_page_label">Go to First Page</span>
+          </button>
+          <button id="lastPage" class="secondaryToolbarButton lastPage" title="Go to Last Page" tabindex="57"
+            data-l10n-id="last_page">
+            <span data-l10n-id="last_page_label">Go to Last Page</span>
+          </button>
+
+          <div class="horizontalToolbarSeparator"></div>
+
+          <button id="pageRotateCw" class="secondaryToolbarButton rotateCw" title="Rotate Clockwise" tabindex="58"
+            data-l10n-id="page_rotate_cw">
+            <span data-l10n-id="page_rotate_cw_label">Rotate Clockwise</span>
+          </button>
+          <button id="pageRotateCcw" class="secondaryToolbarButton rotateCcw" title="Rotate Counterclockwise"
+            tabindex="59" data-l10n-id="page_rotate_ccw">
+            <span data-l10n-id="page_rotate_ccw_label">Rotate Counterclockwise</span>
+          </button>
+
+          <div class="horizontalToolbarSeparator"></div>
+
+          <button id="cursorSelectTool" class="secondaryToolbarButton selectTool toggled"
+            title="Enable Text Selection Tool" tabindex="60" data-l10n-id="cursor_text_select_tool">
+            <span data-l10n-id="cursor_text_select_tool_label">Text Selection Tool</span>
+          </button>
+          <button id="cursorHandTool" class="secondaryToolbarButton handTool" title="Enable Hand Tool" tabindex="61"
+            data-l10n-id="cursor_hand_tool">
+            <span data-l10n-id="cursor_hand_tool_label">Hand Tool</span>
+          </button>
+
+          <div class="horizontalToolbarSeparator"></div>
+
+          <button id="scrollVertical" class="secondaryToolbarButton scrollModeButtons scrollVertical toggled"
+            title="Use Vertical Scrolling" tabindex="62" data-l10n-id="scroll_vertical">
+            <span data-l10n-id="scroll_vertical_label">Vertical Scrolling</span>
+          </button>
+          <button id="scrollHorizontal" class="secondaryToolbarButton scrollModeButtons scrollHorizontal"
+            title="Use Horizontal Scrolling" tabindex="63" data-l10n-id="scroll_horizontal">
+            <span data-l10n-id="scroll_horizontal_label">Horizontal Scrolling</span>
+          </button>
+          <button id="scrollWrapped" class="secondaryToolbarButton scrollModeButtons scrollWrapped"
+            title="Use Wrapped Scrolling" tabindex="64" data-l10n-id="scroll_wrapped">
+            <span data-l10n-id="scroll_wrapped_label">Wrapped Scrolling</span>
+          </button>
+
+          <div class="horizontalToolbarSeparator scrollModeButtons"></div>
+
+          <button id="spreadNone" class="secondaryToolbarButton spreadModeButtons spreadNone toggled"
+            title="Do not join page spreads" tabindex="65" data-l10n-id="spread_none">
+            <span data-l10n-id="spread_none_label">No Spreads</span>
+          </button>
+          <button id="spreadOdd" class="secondaryToolbarButton spreadModeButtons spreadOdd"
+            title="Join page spreads starting with odd-numbered pages" tabindex="66" data-l10n-id="spread_odd">
+            <span data-l10n-id="spread_odd_label">Odd Spreads</span>
+          </button>
+          <button id="spreadEven" class="secondaryToolbarButton spreadModeButtons spreadEven"
+            title="Join page spreads starting with even-numbered pages" tabindex="67" data-l10n-id="spread_even">
+            <span data-l10n-id="spread_even_label">Even Spreads</span>
+          </button>
+
+          <div class="horizontalToolbarSeparator spreadModeButtons"></div>
+
+          <button id="documentProperties" class="secondaryToolbarButton documentProperties" title="Document Properties…"
+            tabindex="68" data-l10n-id="document_properties">
+            <span data-l10n-id="document_properties_label">Document Properties…</span>
+          </button>
+        </div>
+      </div> <!-- secondaryToolbar -->
+
+      <div class="toolbar">
+        <div id="toolbarContainer">
+          <div id="toolbarViewer">
+            <div id="toolbarViewerLeft" style="display:none;">
+              <button id="sidebarToggle" class="toolbarButton" style="display:none;" title="Toggle Sidebar"
+                tabindex="11" data-l10n-id="toggle_sidebar">
+                <span data-l10n-id="toggle_sidebar_label">Toggle Sidebar</span>
               </button>
-              <div class="splitToolbarButtonSeparator"></div>
-              <button id="findNext" class="toolbarButton findNext" title="Find the next occurrence of the phrase" tabindex="93" data-l10n-id="find_next">
-                <span data-l10n-id="find_next_label">Next</span>
+              <div class="toolbarButtonSpacer"></div>
+              <button id="viewFind" class="toolbarButton" style="display: none;" title="Find in Document" tabindex="12"
+                data-l10n-id="findbar">
+                <span data-l10n-id="findbar_label">Find</span>
+              </button>
+              <div class="splitToolbarButton hiddenSmallView">
+                <button class="toolbarButton pageUp" title="Previous Page" id="previous" style="display: none;"
+                  tabindex="13" data-l10n-id="previous">
+                  <span data-l10n-id="previous_label">Previous</span>
+                </button>
+                <div class="splitToolbarButtonSeparator"></div>
+                <button class="toolbarButton pageDown" title="Next Page" style="display: none;" id="next" tabindex="14"
+                  data-l10n-id="next">
+                  <span data-l10n-id="next_label">Next</span>
+                </button>
+              </div>
+              <input type="number" id="pageNumber" class="toolbarField pageNumber" style="display: none;" title="Page"
+                value="1" size="4" min="1" tabindex="15" data-l10n-id="page">
+              <span id="numPages" class="toolbarLabel" style="display: none;"></span>
+            </div>
+            <div id="toolbarViewerRight">
+              <button title="Explain selected text" class="toolbarButton explain" onclick="getSelectedText();"
+                tabindex="33">
+                <span id="explanation_label">Explanation</span>
+              </button>
+
+              <button id="presentationMode" class="toolbarButton presentationMode hiddenLargeView"
+                style="display: none;" title="Switch to Presentation Mode" tabindex="31"
+                data-l10n-id="presentation_mode">
+                <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
+              </button>
+
+              <button id="openFile" class="toolbarButton openFile hiddenLargeView" title="Open File"
+                style="display: none;" tabindex="32" data-l10n-id="open_file">
+                <span data-l10n-id="open_file_label">Open</span>
+              </button>
+
+
+
+              <button id="print" class="toolbarButton print hiddenMediumView" title="Print" tabindex="33"
+                style="display: none;" data-l10n-id="print">
+                <span data-l10n-id="print_label">Print</span>
+              </button>
+
+              <button id="download" class="toolbarButton download hiddenMediumView" title="Download" tabindex="34"
+                data-l10n-id="download">
+                <span data-l10n-id="download_label">Download</span>
+              </button>
+              <a href="#" id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" style="display: none;"
+                title="Current view (copy or open in new window)" tabindex="35" data-l10n-id="bookmark">
+                <span data-l10n-id="bookmark_label">Current View</span>
+              </a>
+
+              <div class="verticalToolbarSeparator hiddenSmallView" style="display: none;"> </div>
+
+              <button id="secondaryToolbarToggle" class="toolbarButton" style="display: none;" title="Tools"
+                tabindex="36" data-l10n-id="tools">
+                <span data-l10n-id="tools_label">Tools</span>
               </button>
             </div>
-          </div>
-
-          <div id="findbarOptionsOneContainer">
-            <input type="checkbox" id="findHighlightAll" class="toolbarField" tabindex="94">
-            <label for="findHighlightAll" class="toolbarLabel" data-l10n-id="find_highlight">Highlight all</label>
-            <input type="checkbox" id="findMatchCase" class="toolbarField" tabindex="95">
-            <label for="findMatchCase" class="toolbarLabel" data-l10n-id="find_match_case_label">Match case</label>
-          </div>
-          <div id="findbarOptionsTwoContainer">
-            <input type="checkbox" id="findEntireWord" class="toolbarField" tabindex="96">
-            <label for="findEntireWord" class="toolbarLabel" data-l10n-id="find_entire_word_label">Whole words</label>
-            <span id="findResultsCount" class="toolbarLabel hidden"></span>
-          </div>
-
-          <div id="findbarMessageContainer">
-            <span id="findMsg" class="toolbarLabel"></span>
-          </div>
-        </div>  <!-- findbar -->
-
-        <div id="secondaryToolbar" class="secondaryToolbar hidden doorHangerRight">
-          <div id="secondaryToolbarButtonContainer">
-            <button id="secondaryPresentationMode" class="secondaryToolbarButton presentationMode visibleLargeView" title="Switch to Presentation Mode" tabindex="51" data-l10n-id="presentation_mode">
-              <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
-            </button>
-
-            <button id="secondaryOpenFile" class="secondaryToolbarButton openFile visibleLargeView" title="Open File" tabindex="52" data-l10n-id="open_file">
-              <span data-l10n-id="open_file_label">Open</span>
-            </button>
-
-            <button id="secondaryPrint" class="secondaryToolbarButton print visibleMediumView" title="Print" tabindex="53" data-l10n-id="print">
-              <span data-l10n-id="print_label">Print</span>
-            </button>
-
-            <button id="secondaryDownload" class="secondaryToolbarButton download visibleMediumView" title="Download" tabindex="54" data-l10n-id="download">
-              <span data-l10n-id="download_label">Download</span>
-            </button>
-
-            <a href="#" id="secondaryViewBookmark" class="secondaryToolbarButton bookmark visibleSmallView" title="Current view (copy or open in new window)" tabindex="55" data-l10n-id="bookmark">
-              <span data-l10n-id="bookmark_label">Current View</span>
-            </a>
-
-            <div class="horizontalToolbarSeparator visibleLargeView"></div>
-
-            <button id="firstPage" class="secondaryToolbarButton firstPage" title="Go to First Page" tabindex="56" data-l10n-id="first_page">
-              <span data-l10n-id="first_page_label">Go to First Page</span>
-            </button>
-            <button id="lastPage" class="secondaryToolbarButton lastPage" title="Go to Last Page" tabindex="57" data-l10n-id="last_page">
-              <span data-l10n-id="last_page_label">Go to Last Page</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <button id="pageRotateCw" class="secondaryToolbarButton rotateCw" title="Rotate Clockwise" tabindex="58" data-l10n-id="page_rotate_cw">
-              <span data-l10n-id="page_rotate_cw_label">Rotate Clockwise</span>
-            </button>
-            <button id="pageRotateCcw" class="secondaryToolbarButton rotateCcw" title="Rotate Counterclockwise" tabindex="59" data-l10n-id="page_rotate_ccw">
-              <span data-l10n-id="page_rotate_ccw_label">Rotate Counterclockwise</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <button id="cursorSelectTool" class="secondaryToolbarButton selectTool toggled" title="Enable Text Selection Tool" tabindex="60" data-l10n-id="cursor_text_select_tool">
-              <span data-l10n-id="cursor_text_select_tool_label">Text Selection Tool</span>
-            </button>
-            <button id="cursorHandTool" class="secondaryToolbarButton handTool" title="Enable Hand Tool" tabindex="61" data-l10n-id="cursor_hand_tool">
-              <span data-l10n-id="cursor_hand_tool_label">Hand Tool</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator"></div>
-
-            <button id="scrollVertical" class="secondaryToolbarButton scrollModeButtons scrollVertical toggled" title="Use Vertical Scrolling" tabindex="62" data-l10n-id="scroll_vertical">
-              <span data-l10n-id="scroll_vertical_label">Vertical Scrolling</span>
-            </button>
-            <button id="scrollHorizontal" class="secondaryToolbarButton scrollModeButtons scrollHorizontal" title="Use Horizontal Scrolling" tabindex="63" data-l10n-id="scroll_horizontal">
-              <span data-l10n-id="scroll_horizontal_label">Horizontal Scrolling</span>
-            </button>
-            <button id="scrollWrapped" class="secondaryToolbarButton scrollModeButtons scrollWrapped" title="Use Wrapped Scrolling" tabindex="64" data-l10n-id="scroll_wrapped">
-              <span data-l10n-id="scroll_wrapped_label">Wrapped Scrolling</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator scrollModeButtons"></div>
-
-            <button id="spreadNone" class="secondaryToolbarButton spreadModeButtons spreadNone toggled" title="Do not join page spreads" tabindex="65" data-l10n-id="spread_none">
-              <span data-l10n-id="spread_none_label">No Spreads</span>
-            </button>
-            <button id="spreadOdd" class="secondaryToolbarButton spreadModeButtons spreadOdd" title="Join page spreads starting with odd-numbered pages" tabindex="66" data-l10n-id="spread_odd">
-              <span data-l10n-id="spread_odd_label">Odd Spreads</span>
-            </button>
-            <button id="spreadEven" class="secondaryToolbarButton spreadModeButtons spreadEven" title="Join page spreads starting with even-numbered pages" tabindex="67" data-l10n-id="spread_even">
-              <span data-l10n-id="spread_even_label">Even Spreads</span>
-            </button>
-
-            <div class="horizontalToolbarSeparator spreadModeButtons"></div>
-
-            <button id="documentProperties" class="secondaryToolbarButton documentProperties" title="Document Properties…" tabindex="68" data-l10n-id="document_properties">
-              <span data-l10n-id="document_properties_label">Document Properties…</span>
-            </button>
-          </div>
-        </div>  <!-- secondaryToolbar -->
-
-        <div class="toolbar">
-          <div id="toolbarContainer">
-            <div id="toolbarViewer">
-              <div id="toolbarViewerLeft" style="display:none;">
-                <button id="sidebarToggle" class="toolbarButton" style="display:none;" title="Toggle Sidebar" tabindex="11" data-l10n-id="toggle_sidebar">
-                  <span data-l10n-id="toggle_sidebar_label">Toggle Sidebar</span>
+            <div id="toolbarViewerMiddle">
+              <div class="splitToolbarButton">
+                <button id="zoomOut" class="toolbarButton zoomOut" title="Zoom Out" tabindex="21"
+                  data-l10n-id="zoom_out">
+                  <span data-l10n-id="zoom_out_label">Zoom Out</span>
                 </button>
-                <div class="toolbarButtonSpacer"></div>
-                <button id="viewFind" class="toolbarButton" style="display: none;" title="Find in Document" tabindex="12" data-l10n-id="findbar">
-                  <span data-l10n-id="findbar_label">Find</span>
-                </button>
-                <div class="splitToolbarButton hiddenSmallView">
-                  <button class="toolbarButton pageUp" title="Previous Page" id="previous" style="display: none;" tabindex="13" data-l10n-id="previous">
-                    <span data-l10n-id="previous_label">Previous</span>
-                  </button>
-                  <div class="splitToolbarButtonSeparator"></div>
-                  <button class="toolbarButton pageDown" title="Next Page" style="display: none;" id="next" tabindex="14" data-l10n-id="next">
-                    <span data-l10n-id="next_label">Next</span>
-                  </button>
-                </div>
-                <input type="number" id="pageNumber" class="toolbarField pageNumber" style="display: none;"  title="Page" value="1" size="4" min="1" tabindex="15" data-l10n-id="page">
-                <span id="numPages" class="toolbarLabel" style="display: none;"></span>
-              </div>
-              <div id="toolbarViewerRight">
-                <button title="Explain selected text" class="toolbarButton explain" onclick="getSelectedText();" tabindex="33"> 
-                  <span id="explanation_label">Explanation</span>
-                </button>
-
-                <button id="presentationMode" class="toolbarButton presentationMode hiddenLargeView" style="display: none;" title="Switch to Presentation Mode" tabindex="31" data-l10n-id="presentation_mode">
-                  <span data-l10n-id="presentation_mode_label">Presentation Mode</span>
-                </button>
-
-                <button id="openFile" class="toolbarButton openFile hiddenLargeView" title="Open File" style="display: none;" tabindex="32" data-l10n-id="open_file">
-                  <span data-l10n-id="open_file_label">Open</span>
-                </button>
-
-                
-
-                 <button id="print" class="toolbarButton print hiddenMediumView" title="Print" tabindex="33" style="display: none;"data-l10n-id="print">
-                  <span data-l10n-id="print_label">Print</span>
-                </button>
-
-                <button id="download" class="toolbarButton download hiddenMediumView" title="Download" tabindex="34" data-l10n-id="download">
-                  <span data-l10n-id="download_label">Download</span>
-                </button>
-                <a href="#" id="viewBookmark" class="toolbarButton bookmark hiddenSmallView" style="display: none;" title="Current view (copy or open in new window)" tabindex="35" data-l10n-id="bookmark">
-                  <span data-l10n-id="bookmark_label">Current View</span>
-                </a>
-
-                <div class="verticalToolbarSeparator hiddenSmallView" style="display: none;">  </div>
-
-                <button id="secondaryToolbarToggle" class="toolbarButton" style="display: none;" title="Tools" tabindex="36" data-l10n-id="tools">
-                  <span data-l10n-id="tools_label">Tools</span>
+                <div class="splitToolbarButtonSeparator"></div>
+                <button id="zoomIn" class="toolbarButton zoomIn" title="Zoom In" tabindex="22" data-l10n-id="zoom_in">
+                  <span data-l10n-id="zoom_in_label">Zoom In</span>
                 </button>
               </div>
-              <div id="toolbarViewerMiddle">
-                <div class="splitToolbarButton">
-                  <button id="zoomOut" class="toolbarButton zoomOut" title="Zoom Out" tabindex="21" data-l10n-id="zoom_out">
-                    <span data-l10n-id="zoom_out_label">Zoom Out</span>
-                  </button>
-                  <div class="splitToolbarButtonSeparator"></div>
-                  <button id="zoomIn" class="toolbarButton zoomIn" title="Zoom In" tabindex="22" data-l10n-id="zoom_in">
-                    <span data-l10n-id="zoom_in_label">Zoom In</span>
-                   </button>
-                </div>
-                <span id="scaleSelectContainer" class="dropdownToolbarButton">
-                  <select id="scaleSelect" title="Zoom" tabindex="23" data-l10n-id="zoom">
-                    <option id="pageAutoOption" title="" value="auto" selected="selected" data-l10n-id="page_scale_auto">Automatic Zoom</option>
-                    <option id="pageActualOption" title="" value="page-actual" data-l10n-id="page_scale_actual">Actual Size</option>
-                    <option id="pageFitOption" title="" value="page-fit" data-l10n-id="page_scale_fit">Page Fit</option>
-                    <option id="pageWidthOption" title="" value="page-width" data-l10n-id="page_scale_width">Page Width</option>
-                    <option id="customScaleOption" title="" value="custom" disabled="disabled" hidden="true"></option>
-                    <option title="" value="0.5" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 50 }'>50%</option>
-                    <option title="" value="0.75" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 75 }'>75%</option>
-                    <option title="" value="1" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 100 }'>100%</option>
-                    <option title="" value="1.25" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 125 }'>125%</option>
-                    <option title="" value="1.5" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 150 }'>150%</option>
-                    <option title="" value="2" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 200 }'>200%</option>
-                    <option title="" value="3" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 300 }'>300%</option>
-                    <option title="" value="4" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 400 }'>400%</option>
-                  </select>
-                </span>
-              </div>
+              <span id="scaleSelectContainer" class="dropdownToolbarButton">
+                <select id="scaleSelect" title="Zoom" tabindex="23" data-l10n-id="zoom">
+                  <option id="pageAutoOption" title="" value="auto" selected="selected" data-l10n-id="page_scale_auto">
+                    Automatic Zoom</option>
+                  <option id="pageActualOption" title="" value="page-actual" data-l10n-id="page_scale_actual">Actual
+                    Size</option>
+                  <option id="pageFitOption" title="" value="page-fit" data-l10n-id="page_scale_fit">Page Fit</option>
+                  <option id="pageWidthOption" title="" value="page-width" data-l10n-id="page_scale_width">Page Width
+                  </option>
+                  <option id="customScaleOption" title="" value="custom" disabled="disabled" hidden="true"></option>
+                  <option title="" value="0.5" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 50 }'>50%
+                  </option>
+                  <option title="" value="0.75" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 75 }'>75%
+                  </option>
+                  <option title="" value="1" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 100 }'>100%
+                  </option>
+                  <option title="" value="1.25" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 125 }'>125%
+                  </option>
+                  <option title="" value="1.5" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 150 }'>150%
+                  </option>
+                  <option title="" value="2" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 200 }'>200%
+                  </option>
+                  <option title="" value="3" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 300 }'>300%
+                  </option>
+                  <option title="" value="4" data-l10n-id="page_scale_percent" data-l10n-args='{ "scale": 400 }'>400%
+                  </option>
+                </select>
+              </span>
             </div>
-            <div id="loadingBar">
-              <div class="progress">
-                <div class="glimmer">
-                </div>
+          </div>
+          <div id="loadingBar">
+            <div class="progress">
+              <div class="glimmer">
               </div>
             </div>
           </div>
         </div>
+      </div>
 
-        <menu type="context" id="viewerContextMenu">
-          <menuitem id="contextFirstPage" label="First Page"
-                    data-l10n-id="first_page"></menuitem>
-          <menuitem id="contextLastPage" label="Last Page"
-                    data-l10n-id="last_page"></menuitem>
-          <menuitem id="contextPageRotateCw" label="Rotate Clockwise"
-                    data-l10n-id="page_rotate_cw"></menuitem>
-          <menuitem id="contextPageRotateCcw" label="Rotate Counter-Clockwise"
-                    data-l10n-id="page_rotate_ccw"></menuitem>
-        </menu>
+      <menu type="context" id="viewerContextMenu">
+        <menuitem id="contextFirstPage" label="First Page" data-l10n-id="first_page">
+        </menuitem>
+        <menuitem id="contextLastPage" label="Last Page" data-l10n-id="last_page">
+        </menuitem>
+        <menuitem id="contextPageRotateCw" label="Rotate Clockwise" data-l10n-id="page_rotate_cw">
+        </menuitem>
+        <menuitem id="contextPageRotateCcw" label="Rotate Counter-Clockwise" data-l10n-id="page_rotate_ccw">
+        </menuitem>
+      </menu>
 
-        <div id="viewerContainer" tabindex="0">
-          <div id="viewer" class="pdfViewer"></div>
+      <div id="viewerContainer" tabindex="0">
+        <div id="viewer" class="pdfViewer"></div>
+      </div>
+
+      <div id="errorWrapper" hidden='true'>
+        <div id="errorMessageLeft">
+          <span id="errorMessage"></span>
+          <button id="errorShowMore" data-l10n-id="error_more_info">
+            More Information
+          </button>
+          <button id="errorShowLess" data-l10n-id="error_less_info" hidden='true'>
+            Less Information
+          </button>
         </div>
-
-        <div id="errorWrapper" hidden='true'>
-          <div id="errorMessageLeft">
-            <span id="errorMessage"></span>
-            <button id="errorShowMore" data-l10n-id="error_more_info">
-              More Information
-            </button>
-            <button id="errorShowLess" data-l10n-id="error_less_info" hidden='true'>
-              Less Information
-            </button>
-          </div>
-          <div id="errorMessageRight">
-            <button id="errorClose" data-l10n-id="error_close">
-              Close
-            </button>
-          </div>
-          <div class="clearBoth"></div>
-          <textarea id="errorMoreInfo" hidden='true' readonly="readonly"></textarea>
+        <div id="errorMessageRight">
+          <button id="errorClose" data-l10n-id="error_close">
+            Close
+          </button>
         </div>
-      </div> <!-- mainContainer -->
+        <div class="clearBoth"></div>
+        <textarea id="errorMoreInfo" hidden='true' readonly="readonly"></textarea>
+      </div>
+    </div> <!-- mainContainer -->
 
-      <div id="overlayContainer" class="hidden">
-        <div id="passwordOverlay" class="container hidden">
-          <div class="dialog">
-            <div class="row">
-              <p id="passwordText" data-l10n-id="password_label">Enter the password to open this PDF file:</p>
-            </div>
-            <div class="row">
-              <input type="password" id="password" class="toolbarField">
-            </div>
-            <div class="buttonRow">
-              <button id="passwordCancel" class="overlayButton"><span data-l10n-id="password_cancel">Cancel</span></button>
-              <button id="passwordSubmit" class="overlayButton"><span data-l10n-id="password_ok">OK</span></button>
-            </div>
+    <div id="overlayContainer" class="hidden">
+      <div id="passwordOverlay" class="container hidden">
+        <div class="dialog">
+          <div class="row">
+            <p id="passwordText" data-l10n-id="password_label">Enter the password to open this PDF file:</p>
           </div>
-        </div>
-        <div id="documentPropertiesOverlay" class="container hidden">
-          <div class="dialog">
-            <div class="row">
-              <span data-l10n-id="document_properties_file_name">File name:</span> <p id="fileNameField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_file_size">File size:</span> <p id="fileSizeField">-</p>
-            </div>
-            <div class="separator"></div>
-            <div class="row">
-              <span data-l10n-id="document_properties_title">Title:</span> <p id="titleField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_author">Author:</span> <p id="authorField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_subject">Subject:</span> <p id="subjectField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_keywords">Keywords:</span> <p id="keywordsField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_creation_date">Creation Date:</span> <p id="creationDateField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_modification_date">Modification Date:</span> <p id="modificationDateField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_creator">Creator:</span> <p id="creatorField">-</p>
-            </div>
-            <div class="separator"></div>
-            <div class="row">
-              <span data-l10n-id="document_properties_producer">PDF Producer:</span> <p id="producerField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_version">PDF Version:</span> <p id="versionField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_page_count">Page Count:</span> <p id="pageCountField">-</p>
-            </div>
-            <div class="row">
-              <span data-l10n-id="document_properties_page_size">Page Size:</span> <p id="pageSizeField">-</p>
-            </div>
-            <div class="separator"></div>
-            <div class="row">
-              <span data-l10n-id="document_properties_linearized">Fast Web View:</span> <p id="linearizedField">-</p>
-            </div>
-            <div class="buttonRow">
-              <button id="documentPropertiesClose" class="overlayButton"><span data-l10n-id="document_properties_close">Close</span></button>
-            </div>
+          <div class="row">
+            <input type="password" id="password" class="toolbarField">
+          </div>
+          <div class="buttonRow">
+            <button id="passwordCancel" class="overlayButton"><span
+                data-l10n-id="password_cancel">Cancel</span></button>
+            <button id="passwordSubmit" class="overlayButton"><span data-l10n-id="password_ok">OK</span></button>
           </div>
         </div>
-        <div id="printServiceOverlay" class="container hidden">
-          <div class="dialog">
-            <div class="row">
-              <span data-l10n-id="print_progress_message">Preparing document for printing…</span>
-            </div>
-            <div class="row">
-              <progress value="0" max="100"></progress>
-              <span data-l10n-id="print_progress_percent" data-l10n-args='{ "progress": 0 }' class="relative-progress">0%</span>
-            </div>
-            <div class="buttonRow">
-              <button id="printCancel" class="overlayButton"><span data-l10n-id="print_progress_close">Cancel</span></button>
-            </div>
+      </div>
+      <div id="documentPropertiesOverlay" class="container hidden">
+        <div class="dialog">
+          <div class="row">
+            <span data-l10n-id="document_properties_file_name">File name:</span>
+            <p id="fileNameField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_file_size">File size:</span>
+            <p id="fileSizeField">-</p>
+          </div>
+          <div class="separator"></div>
+          <div class="row">
+            <span data-l10n-id="document_properties_title">Title:</span>
+            <p id="titleField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_author">Author:</span>
+            <p id="authorField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_subject">Subject:</span>
+            <p id="subjectField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_keywords">Keywords:</span>
+            <p id="keywordsField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_creation_date">Creation Date:</span>
+            <p id="creationDateField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_modification_date">Modification Date:</span>
+            <p id="modificationDateField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_creator">Creator:</span>
+            <p id="creatorField">-</p>
+          </div>
+          <div class="separator"></div>
+          <div class="row">
+            <span data-l10n-id="document_properties_producer">PDF Producer:</span>
+            <p id="producerField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_version">PDF Version:</span>
+            <p id="versionField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_page_count">Page Count:</span>
+            <p id="pageCountField">-</p>
+          </div>
+          <div class="row">
+            <span data-l10n-id="document_properties_page_size">Page Size:</span>
+            <p id="pageSizeField">-</p>
+          </div>
+          <div class="separator"></div>
+          <div class="row">
+            <span data-l10n-id="document_properties_linearized">Fast Web View:</span>
+            <p id="linearizedField">-</p>
+          </div>
+          <div class="buttonRow">
+            <button id="documentPropertiesClose" class="overlayButton"><span
+                data-l10n-id="document_properties_close">Close</span></button>
           </div>
         </div>
-      </div>  <!-- overlayContainer -->
+      </div>
+      <div id="printServiceOverlay" class="container hidden">
+        <div class="dialog">
+          <div class="row">
+            <span data-l10n-id="print_progress_message">Preparing document for printing…</span>
+          </div>
+          <div class="row">
+            <progress value="0" max="100"></progress>
+            <span data-l10n-id="print_progress_percent" data-l10n-args='{ "progress": 0 }'
+              class="relative-progress">0%</span>
+          </div>
+          <div class="buttonRow">
+            <button id="printCancel" class="overlayButton"><span
+                data-l10n-id="print_progress_close">Cancel</span></button>
+          </div>
+        </div>
+      </div>
+    </div> <!-- overlayContainer -->
 
-    </div> <!-- outerContainer -->
-    <div id="printContainer"></div>
-  </body>
+  </div> <!-- outerContainer -->
+  <div id="printContainer"></div>
+</body>
+
 </html>
 <script>
 
-  
 
-  
+
+
 
   function getSelectedText() {
-     if (window.getSelection) {
-       var xhttp = new XMLHttpRequest();
-  xhttp.onreadystatechange = function() {
-  };
-  
-    xhttp.open("POST", "http://timan102.cs.illinois.edu/explanation//explain", true);
-    var text = window.getSelection().toString();
-    xhttp.setRequestHeader("Content-type", "application/json;charset=utf-8");
-  xhttp.send(JSON.stringify({ 'searchString':  text }));
-   // var pdoc =  window.parent.document;
-   // pdoc.postMessage('test')
-// contentWindow.postMessage('test','http://localhost:8093/')
+    if (window.getSelection) {
+      var xhttp = new XMLHttpRequest();
+      xhttp.onreadystatechange = function () {};
+
+      xhttp.open("POST", "http://localhost:8096/explain", true);
+      var text = window.getSelection().toString();
+      xhttp.setRequestHeader("Content-type", "application/json");
+      xhttp.send(JSON.stringify({ 'searchString': text }));
+      // var pdoc =  window.parent.document;
+      // pdoc.postMessage('test')
+      // contentWindow.postMessage('test','http://localhost:8093/')
       // doSearch(window.getSelection().toString());
       //  return window.getSelection().toString();
-     }
-     
-     else if (document.selection) {
-       console.log(document.selection)
+    }
+
+    else if (document.selection) {
+      console.log(document.selection)
       console.log("2")
-         return document.selection.createRange().text;
-     }
-     return '';
+      return document.selection.createRange().text;
+    }
+    return '';
   }
 </script>
-

--- a/ranker.py
+++ b/ranker.py
@@ -1,10 +1,26 @@
 import math
 import sys
+import os
 import time
 import metapy
 import pytoml
 import numpy as np
 import random
+
+from rank_bm25 import BM25Okapi
+
+
+def tokenizer(doc):
+    # prepare the tokenizer;
+    tok = metapy.analyzers.ICUTokenizer(suppress_tags=True)
+    tok = metapy.analyzers.LengthFilter(tok, min=2, max=50)
+    tok = metapy.analyzers.LowercaseFilter(tok)
+    tok = metapy.analyzers.Porter2Filter(tok)
+    tok = metapy.analyzers.ListFilter(tok, "lemur-stopwords.txt", metapy.analyzers.ListFilter.Type.Reject)
+    # set the content;
+    tok.set_content(doc.content())
+    # return tokenized document;
+    return [token for token in tok]
 
 
 def load_ranker(cfg_file, mu):
@@ -14,39 +30,38 @@ def load_ranker(cfg_file, mu):
     configuration file used to load the index.
     """
 
-    # return metapy.index.JelinekMercer(0.5)
-    return metapy.index.DirichletPrior(mu)
+    # parse the dataset file;
+    path = cfg_file[:cfg_file.rfind("/")]
+    data_files = set()
+    corpus = []
+    idx = []
+    with open(f"{path}/dataset-full-corpus.txt", "r") as fh:
+        for line in fh:
+            line = line[:-1]
+            _, file = line.split(" ")
+            data_files.add(file)
+
+    # get all the documents in the dataset and tokenize them accordingly;
+    for file in data_files:
+        with open(os.path.join(path, file), "r") as fh:
+            data = fh.read().strip()
+            doc = metapy.index.Document()
+            doc.content(data)
+            res = tokenizer(doc)
+            corpus.append(res)
+            idx.append(file)
+
+    return {
+        "ranker": BM25Okapi(corpus),
+        "idx": idx,
+    }
 
 
-def score2(ranker, index, query, top_k, alpha):
-    print("Scoring")
-    # print("start")
-    results = ranker.score(index, query, 1000)
-    print(results[:20])
-    for res in results[:20]:
-        doc_name = index.metadata(res[0]).get("doc_name")
-        # print(doc_name,res[1])
-
-    new_results = []
-    new_scores = []
-    updated_results = {}
-    alpha = alpha  # all, 2500, 0.13, 0.666
-    for res in results:
-        doc_name = index.metadata(res[0]).get("doc_name")
-        # print(doc_name)
-        # print(float(index.metadata(res[0]).get('prior')))
-        updated_results[doc_name] = (1 - alpha) * res[1] + alpha * float(
-            index.metadata(res[0]).get("prior")
-        )
-        new_scores.append(updated_results[doc_name])
-
-    # print (sorted(updated_results.items(),key=lambda k:k[1],reverse=True)[:])
-
-    new_idx = np.argsort(np.array(new_scores))[::-1][:top_k]
-
-    for idx in new_idx:
-        new_results.append((results[idx][0], new_scores[idx]))
-    return new_results, updated_results
+def score2(ranker, query, top_k, alpha):
+    print("Scoring...")
+    results = ranker["ranker"].get_top_n(tokenizer(query), ranker["idx"], n=top_k)
+    print("Done...")
+    return results
 
 
 def score1(ranker, index, query, top_k):

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pytoml
 elasticsearch
 flask_socketio
 numpy
+rank-bm25

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-bs4
 flask
 metapy
 pytoml

--- a/templates/slide.html
+++ b/templates/slide.html
@@ -2,309 +2,308 @@
 {% extends "base.html" %}
 {% block nav %}
 <li class="dropdown"><a class="dropdown-toggle" data-toggle="dropdown" href="#">Lectures <span class="caret"></span></a>
-         <ul class="dropdown-menu" style="height:auto; max-width: 850px; left:-225px; max-height:  100vh; overflow:scroll;opacity:0.97;background-color: #E8E8E8;">
-{% for i in lnos %}
-            <li><a href="{{base_url}}/slide/{{course_name}}/{{i}}">{{' '.join(lec_names[i].replace('.txt','').replace('_','-').split('-')).title()}}</a></li>
-             {% endfor %}
-          </ul>
-        </li>
-           
+  <ul class="dropdown-menu"
+    style="height:auto; max-width: 850px; left:-225px; max-height:  100vh; overflow:scroll;opacity:0.97;background-color: #E8E8E8;">
+    {% for i in lnos %}
+    <li><a
+        href="{{base_url}}/slide/{{course_name}}/{{i}}">{{' '.join(lec_names[i].replace('.txt','').replace('_','-').split('-')).title()}}</a>
+    </li>
+    {% endfor %}
+  </ul>
+</li>
+
 {% endblock %}
 
 {% block body %}
 <!-- <script type=text/javascript> -->
-  <!-- $SCRIPT_ROOT = {{ request.script_root|tojson|safe }}; -->
+<!-- $SCRIPT_ROOT = {{ request.script_root|tojson|safe }}; -->
 <!-- </script> -->
 
 <script>
-// $(document).ready(function() {
-//   $.ajaxSetup({ cache: false,async: false, });
-// });
-// });
-// var pdfjsLib = require("pdf.js/build/generic/build/pdf.js");
+  // $(document).ready(function() {
+  //   $.ajaxSetup({ cache: false,async: false, });
+  // });
+  // });
+  // var pdfjsLib = require("pdf.js/build/generic/build/pdf.js");
 
 
-window.addEventListener( "pageshow", function ( event ) {
-// ie compatibility
-
-
-  var historyTraversal = event.persisted || 
-                         ( typeof window.performance != "undefined" && 
-                              window.performance.navigation.type === 2 );
-  if ( historyTraversal ) {
-    // Synchronous ajax request are deprecated so using navigator send beacon
-    // $.getJSON($SCRIPT_ROOT + '/webofslides/log_action', {
-    //     action: 'back_forward',
-    //     route: window.location.pathname
-    //   });
-    logdata = JSON.stringify({
-      action: 'cache_open',
-      route: window.location.pathname
-    });
-    navigator.sendBeacon('{{base_url}}/log_action', logdata);
-  }
-  else{
-    logdata = JSON.stringify({
-      action: 'open',
-      route: window.location.pathname
-    });
-    navigator.sendBeacon('{{base_url}}/log_action', logdata);
-  }
-});
-window.addEventListener("beforeunload", function(event) { 
+  window.addEventListener("pageshow", function (event) {
+    // ie compatibility
+    var historyTraversal = event.persisted ||
+      (typeof window.performance != "undefined" &&
+        window.performance.navigation.type === 2);
+    if (historyTraversal) {
+      // Synchronous ajax request are deprecated so using navigator send beacon
+      // $.getJSON($SCRIPT_ROOT + '/webofslides/log_action', {
+      //     action: 'back_forward',
+      //     route: window.location.pathname
+      //   });
+      logdata = JSON.stringify({
+        action: 'cache_open',
+        route: window.location.pathname
+      });
+      navigator.sendBeacon('{{base_url}}/log_action', logdata);
+    }
+    else {
+      logdata = JSON.stringify({
+        action: 'open',
+        route: window.location.pathname
+      });
+      navigator.sendBeacon('{{base_url}}/log_action', logdata);
+    }
+  });
+  window.addEventListener("beforeunload", function (event) {
     logdata = JSON.stringify({
       action: 'close',
       route: window.location.pathname
     });
     navigator.sendBeacon('{{base_url}}/log_action', logdata);
-  
-});
-
-var hidden, visibilityChange; 
-if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support 
-  hidden = "hidden";
-  visibilityChange = "visibilitychange";
-} else if (typeof document.msHidden !== "undefined") {
-  hidden = "msHidden";
-  visibilityChange = "msvisibilitychange";
-} else if (typeof document.webkitHidden !== "undefined") {
-  hidden = "webkitHidden";
-  visibilityChange = "webkitvisibilitychange";
-}
- 
-
-function handleVisibilityChange() {
-  console.log(document['hidden'])
-  if (document[hidden]) {
-      logdata = JSON.stringify({
-      action: 'hide',
-      route: window.location.pathname
-    });
-    navigator.sendBeacon('{{base_url}}/log_action', logdata);
-  }
-   else {
-      logdata = JSON.stringify({
-      action: 'unhide',
-      route: window.location.pathname
-    });
-    navigator.sendBeacon('{{base_url}}/log_action', logdata);
-  }
-
-}
-
-// Warn if the browser doesn't support addEventListener or the Page Visibility API
-if (typeof document.addEventListener === "undefined" || hidden === undefined) {
-  console.log("requires a browser, such as Google Chrome or Firefox, that supports the Page Visibility API.");
-} else {
-  // Handle page visibility change   
-  document.addEventListener(visibilityChange, handleVisibilityChange, false);
-  }                   
-
-window.addEventListener("DOMContentLoaded", function(event) {
-var relLinks = document.getElementsByClassName("related");
-
-var relLog = function(idx) {
-  console.log('related')
-    logdata = JSON.stringify({
-      action: 'related_'+idx,
-      route: window.location.pathname
-    });
-    navigator.sendBeacon('{{base_url}}/log_action', logdata);
-};
-
-for (var i = 0; i < relLinks.length; i++) {
-    ['click','contextmenu'].forEach(function(e){relLinks[i].addEventListener(e, function(){
-    relLog(this.id);
-} , true);})
-}
-
-
-
-document.getElementById("next").addEventListener('click',function(){  logdata = JSON.stringify({
-      action: 'next',
-      route: window.location.pathname
-    });
-  console.log('next')
-    navigator.sendBeacon('{{base_url}}/log_action', logdata);},true)
-
-
-
-document.getElementById("prev").addEventListener('click',function(){  logdata = JSON.stringify({
-      action: 'prev',
-      route: window.location.pathname
-    });
-
-    navigator.sendBeacon('{{base_url}}/log_action', logdata);},true)
-
-
-})
-$(function() {
-  $('[data-toggle="popover"]').popover({
-    placement:function (context, source) {
-
-        var position = $(source).offset();
-      console.log(position)
-
-      
-        if (position.top < 400){
-            return "bottom";
-        }
-
-        return "top"},
-      container: 'body',
-    trigger : 'hover',
-    html: true
-    
-
   });
-});
+
+  var hidden, visibilityChange;
+  if (typeof document.hidden !== "undefined") { // Opera 12.10 and Firefox 18 and later support 
+    hidden = "hidden";
+    visibilityChange = "visibilitychange";
+  } else if (typeof document.msHidden !== "undefined") {
+    hidden = "msHidden";
+    visibilityChange = "msvisibilitychange";
+  } else if (typeof document.webkitHidden !== "undefined") {
+    hidden = "webkitHidden";
+    visibilityChange = "webkitvisibilitychange";
+  }
 
 
-$(function() {
-          $('#submit').bind('click', function() {
-            var srch = document.getElementById('srch-term').value 
-           $.ajax({
-    type: "POST",
-    url:"{{base_url}}/search_slides",
-    contentType: "application/json;charset=utf-8",
-    data: JSON.stringify({ 'searchString':  srch ,'route':window.location.pathname}),
+  function handleVisibilityChange() {
+    console.log(document['hidden'])
+    if (document[hidden]) {
+      logdata = JSON.stringify({
+        action: 'hide',
+        route: window.location.pathname
+      });
+      navigator.sendBeacon('{{base_url}}/log_action', logdata);
+    }
+    else {
+      logdata = JSON.stringify({
+        action: 'unhide',
+        route: window.location.pathname
+      });
+      navigator.sendBeacon('{{base_url}}/log_action', logdata);
+    }
+  }
 
-    success: function(data){
-      result_section = document.getElementById('result');
-      while (result_section.firstChild) {
+  // Warn if the browser doesn't support addEventListener or the Page Visibility API
+  if (typeof document.addEventListener === "undefined" || hidden === undefined) {
+    console.log("requires a browser, such as Google Chrome or Firefox, that supports the Page Visibility API.");
+  } else {
+    // Handle page visibility change   
+    document.addEventListener(visibilityChange, handleVisibilityChange, false);
+  }
+
+  window.addEventListener("DOMContentLoaded", function (event) {
+
+    var relLinks = document.getElementsByClassName("related");
+
+    var relLog = function (idx) {
+      console.log('related')
+      logdata = JSON.stringify({
+        action: 'related_' + idx,
+        route: window.location.pathname
+      });
+      navigator.sendBeacon('{{base_url}}/log_action', logdata);
+    };
+
+    for (var i = 0; i < relLinks.length; i++) {
+      ['click', 'contextmenu'].forEach(function (e) {
+        relLinks[i].addEventListener(e, function () {
+          relLog(this.id);
+        }, true);
+      })
+    }
+
+    document.getElementById("next").addEventListener('click', function () {
+      logdata = JSON.stringify({
+        action: 'next',
+        route: window.location.pathname
+      });
+      console.log('next')
+      navigator.sendBeacon('{{base_url}}/log_action', logdata);
+    }, true)
+
+    document.getElementById("prev").addEventListener('click', function () {
+      logdata = JSON.stringify({
+        action: 'prev',
+        route: window.location.pathname
+      });
+      navigator.sendBeacon('{{base_url}}/log_action', logdata);
+    }, true)
+  })
+
+  $(function () {
+    $('[data-toggle="popover"]').popover({
+      placement: function (context, source) {
+        var position = $(source).offset();
+        console.log(position)
+        if (position.top < 400) {
+          return "bottom";
+        }
+        return "top"
+      },
+      container: 'body',
+      trigger: 'hover',
+      html: true
+    });
+  });
+
+
+  $(function () {
+    $('#submit').bind('click', function () {
+      var srch = document.getElementById('srch-term').value
+      $.ajax({
+        type: "POST",
+        url: "{{base_url}}/search_slides",
+        contentType: "application/json;charset=utf-8",
+        data: JSON.stringify({ 'searchString': srch, 'route': window.location.pathname }),
+
+        success: function (data) {
+          result_section = document.getElementById('result');
+          while (result_section.firstChild) {
             result_section.removeChild(result_section.firstChild);
-        }
-      h = document.createElement('h2');
-      var searchLog = function(idx) {
-          logdata = JSON.stringify({
-            action: 'search_res_'+idx,
-            route: window.location.pathname
-          });
-          navigator.sendBeacon('{{base_url}}/log_action', logdata);
-      }; 
-      h.innerHTML = 'Search Results';
-      result_section.appendChild(h);
-      for(i=0;i<data['num_results'];i++){
-        if (data['result_type'][i] === "slide") {
-            a = document.createElement('a');
-            a.setAttribute('href', '{{base_url}}/search_slide/' + data['search_course_names'][i] + '/' + data['lnos'][i] + '/' + data['results'][i]);
-            // a.innerHTML = 'Test';
-            a.innerHTML = data['disp_strs'][i]
-            a.setAttribute('id', 'search_' + i)
-            a.setAttribute('class', 'search_res');
-            ['click', 'contextmenu'].forEach(function (e) {
+          }
+          h = document.createElement('h2');
+          var searchLog = function (idx) {
+            logdata = JSON.stringify({
+              action: 'search_res_' + idx,
+              route: window.location.pathname
+            });
+            navigator.sendBeacon('{{base_url}}/log_action', logdata);
+          };
+          h.innerHTML = 'Search Results';
+          result_section.appendChild(h);
+          for (i = 0; i < data['num_results']; i++) {
+            if (data['result_type'][i] === "slide") {
+              a = document.createElement('a');
+              a.setAttribute('href', '{{base_url}}/search_slide/' + data['search_course_names'][i] + '/' + data['lnos'][i] + '/' + data['results'][i]);
+              // a.innerHTML = 'Test';
+              a.innerHTML = data['disp_strs'][i]
+              a.setAttribute('id', 'search_' + i)
+              a.setAttribute('class', 'search_res');
+              ['click', 'contextmenu'].forEach(function (e) {
                 a.addEventListener(e, function () {
-                    searchLog(this.id);
+                  searchLog(this.id);
                 }, true);
-            })
-        } else if(data['result_type'][i] === "piazza") {
-            a = document.createElement('a');
-            a.setAttribute('href', 'https://piazza.com/class/' + data['search_course_names'][i] + '?cid=' + data['results'][i]);
-            a.setAttribute('target', '_blank');
-            // a.innerHTML = 'Test';
-            a.innerHTML = data['disp_strs'][i]
-            a.setAttribute('id', 'search_' + i)
-            a.setAttribute('class', 'search_res');
-            ['click', 'contextmenu'].forEach(function (e) {
+              })
+            } else if (data['result_type'][i] === "piazza") {
+              a = document.createElement('a');
+              a.setAttribute('href', 'https://piazza.com/class/' + data['search_course_names'][i] + '?cid=' + data['results'][i]);
+              a.setAttribute('target', '_blank');
+              // a.innerHTML = 'Test';
+              a.innerHTML = data['disp_strs'][i]
+              a.setAttribute('id', 'search_' + i)
+              a.setAttribute('class', 'search_res');
+              ['click', 'contextmenu'].forEach(function (e) {
                 a.addEventListener(e, function () {
-                    searchLog(this.id);
+                  searchLog(this.id);
                 }, true);
-            })
-        }
+              })
+            }
 
-        result_section.appendChild(a);
+            result_section.appendChild(a);
 
-        if (data['result_type'][i] === "slide") {
-            $('#search_' + i).popover({
+            if (data['result_type'][i] === "slide") {
+              $('#search_' + i).popover({
                 container: 'body',
                 trigger: 'hover',
                 html: true,
                 placement: 'top',
                 title: "<embed type='application/pdf' id='search_slide' src={{pdf_url}}/static/slides/" + data['search_course_names'][i] + '/' + data['lec_names'][i] + '/' + data['results'][i] + "#toolbar=0&navpanes=0&scrollbar=0>"
 
-            })
+              })
+            }
+
+
+            b = document.createElement('br');
+            result_section.appendChild(b);
+            p = document.createElement('p');
+            // p.innerHTML = 'test2';
+            p.innerHTML = data['snippets'][i];
+            result_section.appendChild(p);
+          }
+        },
+        failure: function () {
+          alert('Error searching');
         }
-        
+      });
+    })
+  });
 
-        b = document.createElement('br');
-        result_section.appendChild(b);
-        p = document.createElement('p');
-        // p.innerHTML = 'test2';
-        p.innerHTML = data['snippets'][i];
-        result_section.appendChild(p);
-      }
-    },
-    failure: function() {
-        alert('Error searching');
-    }
-});
-          })
-        })
+  $(document).ready(function () {
+    console.log("a");
+  });
+
+</script>
 
 
- </script>
 
-
-    
- <div class="container-fluid main_cnt">
+<div class="container-fluid main_cnt">
   <div id="explanation-container" class="col-sm-12">
-     <div id="docs-div" class="col-md-12 mx-auto"></div>
-      <br style="clear: both;">
-      <div>
+    <div id="docs-div" class="col-md-12 mx-auto"></div>
+    <br style="clear: both;">
+    <div>
       <button type="button" class="btn btn-success pull-left" id="helpfulButton">Helpful</button>
       <button type="button" class="btn btn-danger pull-right" id="notHelpfulButton">Not Helpful</button>
     </div>
-    </div>
-<div class="row main_row" >
-<div class="col-sm-12 main"> 
-  <h2>{{' '.join(course_name.split('-')).title()}}</h2>
-  <p>{{slide_name.split('----')[-1][:-4].title()}}</p>
-    <div style="overflow:auto;-webkit-overflow-scrolling:touch">
-  <iframe id='main_slide' type='application/pdf' src="{{pdf_url}}/build/generic/web/viewer.html?file={{pdf_url}}/static/slides/{{course_name}}/{{lec_name}}/{{slide_name}}#toolbar=0&navpanes=0&scrollbar=0&view=FitH"
-  ></iframe>
-</div>
+  </div>
+  <div class="row main_row">
+    <div class="col-sm-12 main">
+      <h2>{{' '.join(course_name.split('-')).title()}}</h2>
+      <p>{{slide_name.split('----')[-1][:-4].title()}}</p>
+      <div style="overflow:auto;-webkit-overflow-scrolling:touch">
+        <iframe id='main_slide' type='application/pdf'
+          src="{{pdf_url}}/build/generic/web/viewer.html?file={{pdf_url}}/static/slides/{{course_name}}/{{lec_name}}/{{slide_name}}#toolbar=0&navpanes=0&scrollbar=0&view=FitH"></iframe>
+      </div>
 
-  
-  <button type="button" id="prev" class="btn btn-success pull-left" style="margin-top: 20px" onclick="location.href='{{base_url}}/prev_slide/{{course_name}}/{{lno}}/{{slide_name}}'">Prev Slide</button>
-  <button type="button" id="next" class="btn btn-success pull-right" style="margin-top:20px" onclick="location.href='{{base_url}}/next_slide/{{course_name}}/{{lno}}/{{slide_name}}'">Next Slide</button>
+
+      <button type="button" id="prev" class="btn btn-success pull-left" style="margin-top: 20px"
+        onclick="location.href='{{base_url}}/prev_slide/{{course_name}}/{{lno}}/{{slide_name}}'">Prev Slide</button>
+      <button type="button" id="next" class="btn btn-success pull-right" style="margin-top:20px"
+        onclick="location.href='{{base_url}}/next_slide/{{course_name}}/{{lno}}/{{slide_name}}'">Next Slide</button>
+    </div>
+
+
+    <div class="sidebar">
+      <ul class="nav nav-sidebar">
+
+        <h2>Related slides</h2>
+
+        {% for i in range(num_related_slides) %}
+        <li>
+          <a href="{{base_url}}/related_slide/{{related_course_names[i]}}/{{rel_lnos[i]}}/{{related_slides[i]}}"
+            id="{{i}}" class="related" data-toggle="popover" style="color:{{disp_color[i]}};"
+            title="<embed type='application/pdf' src={{pdf_url}}/static/slides/{{related_course_names[i]}}/{{rel_lec_names[i]}}/{{related_slides[i]}}#toolbar=0&navpanes=0&scrollbar=0&view=Fit width='220px' height:'100px' >">{{disp_str[i]}}
+          </a>
+        </li>
+        {% endfor %}
+
+      </ul>
+    </div>
   </div>
 
-
-            <div class="sidebar">
-                <ul class="nav nav-sidebar">
-            <h2>Related slides</h2>
-       
-          {% for i in range(num_related_slides) %}
-    <li>
-    
-      <a href="{{base_url}}/related_slide/{{related_course_names[i]}}/{{rel_lnos[i]}}/{{related_slides[i]}}" id="{{i}}" class="related" data-toggle="popover" style="color:{{disp_color[i]}};" title="<embed type='application/pdf' src={{pdf_url}}/static/slides/{{related_course_names[i]}}/{{rel_lec_names[i]}}/{{related_slides[i]}}#toolbar=0&navpanes=0&scrollbar=0&view=Fit width='220px' height:'100px' >" >{{disp_str[i]}} </a>
-    
-    
-    </li>
-    {% endfor %}
-            
-        </ul>
-    </div>
-     </div>
-     
-    <div class="row" style="display: flex;">
- <div class="col-md-12">
- <div class="input-group add-on" >
-      <input class="form-control" placeholder="Search" name="srch-term" id="srch-term" type="text">
-      <div class="input-group-btn">
-        <button class="btn btn-default" id="submit" type="submit"><i class="glyphicon glyphicon-search"></i></button>
+  <div class="row" style="display: flex;">
+    <div class="col-md-12">
+      <div class="input-group add-on">
+        <input class="form-control" placeholder="Search" name="srch-term" id="srch-term" type="text">
+        <div class="input-group-btn">
+          <button class="btn btn-default" id="submit" type="submit"><i class="glyphicon glyphicon-search"></i></button>
+        </div>
       </div>
     </div>
- </div>
-</div>
- <div class="row" style="display: flex;padding: 20px;">
-<div class="col-md-9" id="result" padding-bottom="15px">
- </div>
-</div>
+  </div>
+  <div class="row" style="display: flex;padding: 20px;">
+    <div class="col-md-9" id="result" padding-bottom="15px">
     </div>
+  </div>
+</div>
 
 
 
 {% endblock %}
-
-  


### PR DESCRIPTION
@jessehenn Made some changes to the ES ingest and search. Now all the information comes out of ES, but the `create_es_index.py` uses the piazza parser. You can disregard any of the HTML changes, just ran a formatter against some of those files to make them more readable.

- Swapped out the ranking library from "metapy" to "rank-bm25", given that Okapi BM25 seems to be the gold standard anyway and metapy kept hanging for me. 
- Discovered the explanation endpoint, and fixed the code for it. This allows you to highlight text on the slides and search for a definition of it, if you click on the scholar hat in the top right corner. This is currently the only feature even using ranking as data retrieval, but without comments or docs it is hard to exactly tell how they did their ranking, so I removed some things for it.

We can probably re-use their code and get Piazza posts from the ranker, rather than ES if we want to. Thoughts?

![Screen Shot 2020-11-24 at 7 02 11 PM](https://user-images.githubusercontent.com/70975087/100168807-962e2000-2e87-11eb-85b0-b48f76e5b2c5.png)
